### PR TITLE
Feature/daeun

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -7,6 +7,9 @@ import StackNavigator from './navigation/StackNavigator';
 
 export default function App() {
   LogBox.ignoreLogs(['Warning: ...']);
+  LogBox.ignoreLogs([
+    'Non-serializable values were found in the navigation state',
+  ]);
 
   return (
     <NavigationContainer>

--- a/components/card/DetailCard.jsx
+++ b/components/card/DetailCard.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { SmallCategoryButton, HashtagButton } from '../button';
 
 export default function DetailCard() {
   return (
-    <TouchableOpacity style={styles.cardContainer}>
+    <View style={styles.cardContainer}>
       <View style={styles.row}>
         <Text style={styles.nickname}>닉네임</Text>
         <Text style={styles.authorInfoBox}>백엔드 개발자 / Python</Text>
@@ -27,7 +27,7 @@ export default function DetailCard() {
       <View style={styles.hashtagRow}>
         <HashtagButton title={'Python'} />
       </View>
-    </TouchableOpacity>
+    </View>
   );
 }
 

--- a/pages/post/SubList.jsx
+++ b/pages/post/SubList.jsx
@@ -7,18 +7,18 @@ import { SearchBar } from '../../components/input';
 import { MainCard } from '../../components/card';
 
 export default function SubList({ route }) {
-  const data = route.params;
-  const navigation = data.navigation;
-  const title = data.title + ' - ' + data.category;
+  let data = route.params;
+  let navigation = data.navigation;
+  let title = data.title + ' - ' + data.category;
   return (
     <View style={styles.container}>
       <HeaderBack navigation={navigation} title={title} />
       <SearchBar />
       <ScrollView>
         <View style={styles.content}>
-          <MainCard />
-          <MainCard />
-          <MainCard />
+          <MainCard navigation={navigation} />
+          <MainCard navigation={navigation} />
+          <MainCard navigation={navigation} />
         </View>
       </ScrollView>
     </View>


### PR DESCRIPTION
상세페이지 TouchableOpacity는 View로 바꾸고 navigation 오류 해결했습니다~!

근데 'Non-serializable values were found in the navigation state' warning이 떠서 검색해보니까

일단 경고라 크리티컬 하진 않은데 해결 방법 중 하나로 해당 경고창이 안뜨게 하는 방법이 있어서

우선 임시로 LogBox로 해결해뒀고 추후에 데이터 돌릴 때 이거 빼도 같은 오류 나면 다른 방법으로 근본적인 해결책을 찾으려고요!

https://reactnavigation.org/docs/troubleshooting/ <- 여기 공식문서에 troubleshooting 관련 내용 있습니다.